### PR TITLE
fix: use globalThis instead of window

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,4 +1,4 @@
-const crypto = window.crypto;
+const crypto = globalThis.crypto;
 const subtle = crypto.subtle ?? (crypto as any).webkitSubtle;
 
 function utf8ToBytes(str: string): Uint8Array {


### PR DESCRIPTION
`window.crypto` throws an error in webworker or some other environments. `globalThis.crypto`  will fix this.